### PR TITLE
Headers already sent error

### DIFF
--- a/classes/class-ss-wc-integration-mailchimp.php
+++ b/classes/class-ss-wc-integration-mailchimp.php
@@ -320,7 +320,7 @@ class SS_WC_Integration_MailChimp extends WC_Integration {
 
 
 	/**
-	 * Display message to user if there is an issue with the MailChimp API call is not available
+	 * Display message to user if there is an issue with the MailChimp API call
 	 *
 	 * @since 1.0
 	 * @param void


### PR DESCRIPTION
Fixed an issue that would throw a 'headers already sent' PHP error message to the browser when activating the plugin without a MailChimp API key entered.
