### PR TITLE
subcriptions hook (with order and list id)

### DIFF
--- a/classes/class-ss-wc-integration-mailchimp.php
+++ b/classes/class-ss-wc-integration-mailchimp.php
@@ -436,13 +436,18 @@ class SS_WC_Integration_MailChimp extends WC_Integration {
 		if ( $api->errorCode && $api->errorCode != 214 ) {
 			self::log( 'WooCommerce MailChimp subscription failed: (' . $api->errorCode . ') ' . $api->errorMessage );
 
+			// Compability to old hook
+			do_action( 'ss_wc_mailchimp_subscribed', $email );
+
+			// New hook for failing operations
 			do_action( 'ss_wc_mailchimp_subscription_failed', $email, array( 'list_id' => $listid, 'order_id' => $order_id ) );
 
 			// Email admin
 			wp_mail( get_option('admin_email'), __( 'WooCommerce MailChimp subscription failed', 'ss_wc_mailchimp' ), '(' . $api->errorCode . ') ' . $api->errorMessage );
 		}
 		else {
-			do_action( 'ss_wc_mailchimp_subscribed', $email, array( 'list_id' => $listid, 'order_id' => $order_id ) );
+			// Hook on success
+			do_action( 'ss_wc_mailchimp_subscription_success', $email, array( 'list_id' => $listid, 'order_id' => $order_id ) );
 		}
 	}
 

--- a/classes/class-ss-wc-integration-mailchimp.php
+++ b/classes/class-ss-wc-integration-mailchimp.php
@@ -436,10 +436,13 @@ class SS_WC_Integration_MailChimp extends WC_Integration {
 		if ( $api->errorCode && $api->errorCode != 214 ) {
 			self::log( 'WooCommerce MailChimp subscription failed: (' . $api->errorCode . ') ' . $api->errorMessage );
 
-			do_action( 'ss_wc_mailchimp_subscribed', $email );
+			do_action( 'ss_wc_mailchimp_subscription_failed', $email, array( 'list_id' => $listid, 'order_id' => $order_id ) );
 
 			// Email admin
 			wp_mail( get_option('admin_email'), __( 'WooCommerce MailChimp subscription failed', 'ss_wc_mailchimp' ), '(' . $api->errorCode . ') ' . $api->errorMessage );
+		}
+		else {
+			do_action( 'ss_wc_mailchimp_subscribed', $email, array( 'list_id' => $listid, 'order_id' => $order_id ) );
 		}
 	}
 


### PR DESCRIPTION
`ss_wc_mailchimp_subscribed` action is confusing, as it fires when subscription fails. Introducing different hook for success and failing operations and providing list and order ID with it. 