### PR TITLE
Opt-in checkbox position

### DIFF
--- a/classes/class-ss-wc-integration-mailchimp.php
+++ b/classes/class-ss-wc-integration-mailchimp.php
@@ -261,7 +261,8 @@ class SS_WC_Integration_MailChimp extends WC_Integration {
 					'default'     => 'billing',
 					'options'     => array(
 						'billing'   => __( 'Billing', 'ss_wc_mailchimp' ),
-						'order'     => __( 'Order', 'ss_wc_mailchimp' )
+						'order'     => __( 'Order', 'ss_wc_mailchimp' ),
+						'account'   => __( 'Account', 'ss_wc_mailchimp' ),
 					)
 				)
 			);


### PR DESCRIPTION
hi,

this is a small add to allow the opt-in checkbox to appear under the account fields on checkout page. I need it because the billing fields are hidden (the box is closed by default). 

what do you think ?

thanks for this very usefull plugin :)

séb.