### PR TITLE
WPML add opt-in label for translation

### DIFF
--- a/includes/class-ss-wc-mailchimp-plugin.php
+++ b/includes/class-ss-wc-mailchimp-plugin.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 /**
  * WooCommerce MailChimp plugin main class
@@ -267,6 +267,11 @@ final class SS_WC_MailChimp_Plugin {
 			update_option( $this->namespace_prefixed( $key ), $value );
 		}
 
+		// WMPL register string for translation
+		if (function_exists( 'icl_object_id' )) {
+	    	do_action( 'wpml_register_single_string', 'ss_wc_mailchimp', 'opt_in_label', $settings['opt_in_label'] );
+	    }
+
 	} //end function save_settings
 
 	/**
@@ -453,7 +458,7 @@ final class SS_WC_MailChimp_Plugin {
 
 	/**
      * Load scripts required for admin
-     * 
+     *
      * @access public
      * @return void
      */

--- a/includes/class-ss-wc-mailchimp-plugin.php
+++ b/includes/class-ss-wc-mailchimp-plugin.php
@@ -191,6 +191,10 @@ final class SS_WC_MailChimp_Plugin {
 	 * @return string
 	 */
 	public function opt_in_label() {
+		if ( function_exists( 'icl_object_id' ) ) {
+			return apply_filters( 'wpml_translate_single_string', $this->settings[ 'opt_in_label' ], 'ss_wc_mailchimp', 'opt_in_label' );
+		}
+
 		return $this->settings[ 'opt_in_label' ];
 	}
 

--- a/woocommerce-mailchimp.php
+++ b/woocommerce-mailchimp.php
@@ -37,4 +37,8 @@ function SSWCMC() {
 }
 
 // Get WooCommerce Mailchimp Running.
-SSWCMC();
+if ( function_exists( 'icl_object_id' ) ) {
+	add_action( 'wpml_st_loaded', 'SSWCMC' );
+} else {
+	SSWCMC();
+}


### PR DESCRIPTION
I use this plugin in an on-going project of mine. The user-generated admin text 'Opt-in Field Label' is not visible in WPML String translation. So, I have added a few lines to work it out. The code could be much cleaner if I used some constants instead of e.g.: `'ss_wc_mailchimp'` for the translation context. I just didn't have time to find it.

I've bumped into the problem that the plugin had been loaded before WPML, so the action `wpml_register_single_string` could not be executed. So, I have changed the way SSWC is started. It is now hooked after loading WPML.

Another thing is, I considered loading the proper translation `SS_WC_MailChimp_Plugin::settings()` but I was unsure whether the settings get loaded upon the change of the language context. So, I rather put it into `SS_WC_MailChimp_Plugin::opt_in_label()`.