### PR TITLE
Fix "Invalid argument supplied for foreach" warning in settings

### DIFF
--- a/includes/class-ss-wc-settings-mailchimp.php
+++ b/includes/class-ss-wc-settings-mailchimp.php
@@ -613,7 +613,7 @@ if ( ! class_exists( 'SS_WC_Settings_MailChimp' ) ) {
 			if ( $this->mailchimp() && $this->has_list() ) {
 				$interest_groups = $this->mailchimp()->get_interest_categories_with_interests( $this->get_list() );
 			} else {
-				return false;
+				return array();
 			}
 
 			if ( $interest_groups === false ) {
@@ -621,7 +621,7 @@ if ( ! class_exists( 'SS_WC_Settings_MailChimp' ) ) {
 				add_action( 'admin_notices',         array( $this, 'mailchimp_api_error_msg' ) );
 				add_action( 'network_admin_notices', array( $this, 'mailchimp_api_error_msg' ) );
 
-				return false;
+				return array();
 
 			}
 


### PR DESCRIPTION
Fix: https://github.com/anderly/woocommerce-mailchimp/issues/19